### PR TITLE
Add failing e2e test skeleton

### DIFF
--- a/tests/e2e/test_end_to_end_trade_flow.py
+++ b/tests/e2e/test_end_to_end_trade_flow.py
@@ -1,0 +1,15 @@
+import pytest
+
+sample_insight = {"symbol": "AAPL", "price": 150.0}
+
+
+def test_end_to_end_trade_flow(client):
+    """Canonical failing integration test for the MVP."""
+    # GIVEN all three agents running in the cluster
+    insight = client.post("/a2a/publish", json=sample_insight)
+    # WHEN MarketAnalyst publishes an insight on `market-insight`
+    plan = client.wait_for("trade-plan", timeout=30)
+    email = client.wait_for("email-notify", timeout=30)
+    # THEN Planner emits a `trade-plan` and Mailer sends an email via Gmail MCP
+    assert plan["status"] == "READY"
+    assert email["sent"] is True


### PR DESCRIPTION
## Summary
- set up e2e folder
- add canonical failing integration test from the HighLevelSpec

## Testing
- `pytest -q` *(fails: fixture 'client' not found)*

------
https://chatgpt.com/codex/tasks/task_e_6846258aa44c8330a80085f354589ae8