### PR TITLE
Implement basic in-memory message bus and stub agent workflows

### DIFF
--- a/agents/mailer/__init__.py
+++ b/agents/mailer/__init__.py
@@ -1,0 +1,1 @@
+from .main import run

--- a/agents/mailer/main.py
+++ b/agents/mailer/main.py
@@ -1,10 +1,36 @@
-"""Mailer agent placeholder."""
+"""Mailer agent placeholder that emits email notifications."""
 
-def run():
-    print("Mailer starting")
+from __future__ import annotations
 
-def main():
-    run()
+from threading import Event
+
+from message_bus import MessageBus
+
+
+def run(bus: MessageBus, stop_event: Event) -> None:
+    """Consume trade plans and publish email notifications."""
+    plan_q = bus.subscribe("trade-plan")
+    while not stop_event.is_set():
+        try:
+            plan = bus.wait_for(plan_q, timeout=0.1)
+        except TimeoutError:
+            continue
+
+        email = {"sent": True, "plan": plan}
+        bus.publish("email-notify", email)
+
+
+def main() -> None:
+    import threading
+    bus = MessageBus()
+    stop = Event()
+    t = threading.Thread(target=run, args=(bus, stop))
+    t.start()
+    try:
+        t.join()
+    finally:
+        stop.set()
+
 
 if __name__ == "__main__":
     main()

--- a/agents/market_analyst/__init__.py
+++ b/agents/market_analyst/__init__.py
@@ -1,0 +1,1 @@
+from .main import run

--- a/agents/planner/__init__.py
+++ b/agents/planner/__init__.py
@@ -1,0 +1,1 @@
+from .main import run

--- a/agents/planner/main.py
+++ b/agents/planner/main.py
@@ -1,10 +1,36 @@
-"""Planner agent placeholder."""
+"""Planner agent placeholder with simple rule-based trade plan."""
 
-def run():
-    print("Planner starting")
+from __future__ import annotations
 
-def main():
-    run()
+from threading import Event
+
+from message_bus import MessageBus
+
+
+def run(bus: MessageBus, stop_event: Event) -> None:
+    """Consume market insights and publish trade plans."""
+    insight_q = bus.subscribe("market-insight")
+    while not stop_event.is_set():
+        try:
+            insight = bus.wait_for(insight_q, timeout=0.1)
+        except TimeoutError:
+            continue
+
+        plan = {"status": "READY", "insight": insight}
+        bus.publish("trade-plan", plan)
+
+
+def main() -> None:
+    import threading
+    bus = MessageBus()
+    stop = Event()
+    t = threading.Thread(target=run, args=(bus, stop))
+    t.start()
+    try:
+        t.join()
+    finally:
+        stop.set()
+
 
 if __name__ == "__main__":
     main()

--- a/message_bus.py
+++ b/message_bus.py
@@ -1,0 +1,27 @@
+from __future__ import annotations
+
+from collections import defaultdict
+from queue import Queue, Empty
+from typing import Any, Dict, List
+
+
+class MessageBus:
+    """Simple in-memory message bus used for tests."""
+
+    def __init__(self) -> None:
+        self._topics: Dict[str, List[Queue]] = defaultdict(list)
+
+    def publish(self, topic: str, message: Any) -> None:
+        for q in list(self._topics[topic]):
+            q.put(message)
+
+    def subscribe(self, topic: str) -> Queue:
+        q: Queue = Queue()
+        self._topics[topic].append(q)
+        return q
+
+    def wait_for(self, queue: Queue, timeout: int | None = None) -> Any:
+        try:
+            return queue.get(timeout=timeout)
+        except Empty as exc:
+            raise TimeoutError("Timed out waiting for message") from exc

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,14 +1,53 @@
+import os
+import sys
+import threading
+from typing import Any
+
 import pytest
 
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+
+from message_bus import MessageBus
+from agents import planner, mailer
+
+
 class DummyClient:
-    """Placeholder HTTP client for tests."""
+    """Simple client that interacts with an in-memory MessageBus."""
 
-    def post(self, path: str, json: dict):
-        raise NotImplementedError("publish not implemented")
+    def __init__(self) -> None:
+        self.bus = MessageBus()
+        self.trade_plan_q = self.bus.subscribe("trade-plan")
+        self.email_q = self.bus.subscribe("email-notify")
+        self._stop = threading.Event()
+        self._threads = [
+            threading.Thread(target=planner.run, args=(self.bus, self._stop), daemon=True),
+            threading.Thread(target=mailer.run, args=(self.bus, self._stop), daemon=True),
+        ]
+        for t in self._threads:
+            t.start()
 
-    def wait_for(self, topic: str, timeout: int = 30):
-        raise NotImplementedError("wait_for not implemented")
+    def post(self, path: str, json: dict) -> None:
+        if path != "/a2a/publish":
+            raise ValueError(f"Unsupported path: {path}")
+        self.bus.publish("market-insight", json)
+
+    def wait_for(self, topic: str, timeout: int = 30) -> Any:
+        if topic == "trade-plan":
+            return self.bus.wait_for(self.trade_plan_q, timeout)
+        if topic == "email-notify":
+            return self.bus.wait_for(self.email_q, timeout)
+        raise ValueError(f"Unsupported topic: {topic}")
+
+    def close(self) -> None:
+        self._stop.set()
+        for t in self._threads:
+            t.join(timeout=1)
+
 
 @pytest.fixture
 def client():
-    return DummyClient()
+    c = DummyClient()
+    try:
+        yield c
+    finally:
+        c.close()


### PR DESCRIPTION
## Summary
- add a simple publish/subscribe `MessageBus`
- stub out planner and mailer agents to use the bus
- expose agent `run` functions via package `__init__`
- update the `DummyClient` fixture to drive agents in tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68462abc91c88330893cc58f14f0cc82